### PR TITLE
Add AI studio setup script

### DIFF
--- a/instructions.yml
+++ b/instructions.yml
@@ -53,7 +53,9 @@ Applying the Cipher Internally:
                <file:///mnt/data/NyayaSutraPrimer.json>,
                <file:///mnt/data/heidegger_logic_primer.json>,
                <file:///mnt/data/Formulae.json>,
-               <file:///mnt/data/tools.zip> .
+               <file:///mnt/data/tools.zip>,
+               <file:///workspace/theAletheometer/requirements.txt>,
+               <file:///workspace/theAletheometer/scripts/setup_ai_studio.py> .
 
 :BasicCipherKeyComponents
   a owl:Class ;

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,21 @@
+# Unified dependencies for AutoGPT, LibreChat (Python components if any), and theAletheometer
+numpy>=1.21
+openai>=1.0
+pydantic>=1.10
+python-dotenv>=1.0
+requests>=2.28
+tiktoken>=0.4
+colorama>=0.4
+playsound==1.2.2
+duckduckgo-search>=3.9
+gptcache>=0.1
+altgraph>=0.17
+apscheduler>=3.10
+bcrypt>=4.0
+distro>=1.8
+jsonschema>=4.19
+websockets>=10.4
+uvicorn>=0.24
+fastapi>=0.110
+click>=8.1
+gitpython>=3.1

--- a/scripts/setup_ai_studio.py
+++ b/scripts/setup_ai_studio.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Setup script to prepare an AI studio environment.
+
+This script installs dependencies from ``requirements.txt`` and optionally
+creates a ``.env`` file with API keys for LLM services such as OpenAI or
+Anthropic. It unifies packages needed by AutoGPT, LibreChat, and the
+Aletheometer.
+"""
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+REQ_FILE = ROOT / 'requirements.txt'
+ENV_FILE = ROOT / '.env'
+
+
+def install_requirements() -> None:
+    """Install required Python packages using pip."""
+    if REQ_FILE.exists():
+        subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-r', str(REQ_FILE)])
+    else:
+        print(f"Requirements file not found: {REQ_FILE}")
+
+
+def configure_api_keys() -> None:
+    """Prompt the user for API keys and store them in .env."""
+    print('Configure API keys for LLM services (leave blank to skip).')
+    keys = {}
+    try:
+        keys['OPENAI_API_KEY'] = input('OpenAI API key: ').strip()
+        keys['ANTHROPIC_API_KEY'] = input('Anthropic API key: ').strip()
+        keys['HUGGINGFACE_API_KEY'] = input('Hugging Face API key: ').strip()
+    except KeyboardInterrupt:
+        print('\nSetup cancelled by user.')
+        sys.exit(1)
+
+    with ENV_FILE.open('w') as f:
+        for k, v in keys.items():
+            if v:
+                f.write(f"{k}={v}\n")
+    print(f'API keys written to {ENV_FILE}')
+
+
+def main() -> None:
+    install_requirements()
+    configure_api_keys()
+    print('AI studio setup complete.')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/setup_ai_studio.py` for installing dependencies and configuring API keys
- link the new script in `instructions.yml` for reference

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883bc27a1ec832bae1ac15a2e06a215