### PR TITLE
Fix startup error in PTM script

### DIFF
--- a/scripts/ptm.py
+++ b/scripts/ptm.py
@@ -1,4 +1,3 @@
-python
 from enum import Enum
 from dataclasses import dataclass, field
 from typing import Dict, List, Tuple, Optional, Set
@@ -6,6 +5,7 @@ import math
 import time
 import numpy as np
 from collections import defaultdict
+from itertools import cycle
 
 class CoreOperator(Enum):
     """Core operators from the Polychronological Symphony"""


### PR DESCRIPTION
## Summary
- remove stray `python` line at the start of `ptm.py`
- add missing `cycle` import
- ensure the script ends with a newline

## Testing
- `python3 -m py_compile scripts/ptm.py`

------
https://chatgpt.com/codex/tasks/task_e_687fe440854c832b8239440196dad975