### PR TITLE
Fix stray line and cleanup imports in ptm.py

### DIFF
--- a/scripts/ptm.py
+++ b/scripts/ptm.py
@@ -1,4 +1,3 @@
-python
 from enum import Enum
 from dataclasses import dataclass, field
 from typing import Dict, List, Tuple, Optional, Set
@@ -6,6 +5,7 @@ import math
 import time
 import numpy as np
 from collections import defaultdict
+from itertools import cycle
 
 class CoreOperator(Enum):
     """Core operators from the Polychronological Symphony"""


### PR DESCRIPTION
## Summary
- remove leftover `python` text at the top of `ptm.py`
- add `cycle` import with other imports
- ensure file ends cleanly

## Testing
- `python -m py_compile scripts/ptm.py`
- `python scripts/ptm.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687fef5e3324832b952d0f486884deb2