### PR TITLE
Fix JSON syntax

### DIFF
--- a/instructions.json
+++ b/instructions.json
@@ -10,7 +10,10 @@
                 "reflect": "Consider different levels and perspectives of existence by integrating spatial (x, y, z axes) and temporal (passage, periodicity, presence) dimensions.",
                 "revise": "Adjust reasoning strategies based on insights gained from multi-dimensional analysis.",
                 "source": {
-                    "source_file": "ontology.xml""EpistemicColorSpace.json",
+                    "source_files": [
+                        "ontology.xml",
+                        "EpistemicColorSpace.json"
+                    ],
                     "description": "Defines the MetaOntological framework and the six-dimensional hypersphere model.",
                     "function": "Provides the foundational structure for multi-dimensional reasoning and worldview integration."
                 }
@@ -106,7 +109,7 @@
                     ]
                 }
             }
-        }
+        },
       {
             "step_number": 5,
             "name": "Incorporate Second-Order Thinking",

--- a/instructions_reduced_for_chatGPT.json
+++ b/instructions_reduced_for_chatGPT.json
@@ -10,8 +10,10 @@
                 "reflect": "Integrate spatial (x, y, z) and temporal (passage, periodicity, presence) dimensions to consider different existence levels.",
                 "revise": "Adjust reasoning based on multi-dimensional analysis.",
                 "source": {
-                    "source_file": "ontology.xml",
-                    "EpistemicColorSpace.json",
+                    "source_files": [
+                        "ontology.xml",
+                        "EpistemicColorSpace.json"
+                    ],
                     "description": "Defines the MetaOntological framework and six-dimensional model.",
                     "function": "Provides structure for multi-dimensional reasoning."
                 }


### PR DESCRIPTION
## Summary
- correct `instructions.json` and `instructions_reduced_for_chatGPT.json` so that `ontology.xml` and `EpistemicColorSpace.json` are properly separated
- ensure `instructions.json` syntax between steps is valid

## Testing
- `python3 - <<'PY'
import json,sys
for fname in ['instructions.json','instructions_reduced_for_chatGPT.json']:
    print('Validating', fname)
    with open(fname) as f:
        json.load(f)
    print('OK')
PY`

------
https://chatgpt.com/codex/tasks/task_e_6883990bf8f8832ba127c4c434b2bfa7