### PR TITLE
Fix comma errors in instruction JSON files

### DIFF
--- a/instructions.json
+++ b/instructions.json
@@ -10,7 +10,10 @@
                 "reflect": "Consider different levels and perspectives of existence by integrating spatial (x, y, z axes) and temporal (passage, periodicity, presence) dimensions.",
                 "revise": "Adjust reasoning strategies based on insights gained from multi-dimensional analysis.",
                 "source": {
-                    "source_file": "ontology.xml""EpistemicColorSpace.json",
+                    "source_files": [
+                        "ontology.xml",
+                        "EpistemicColorSpace.json"
+                    ],
                     "description": "Defines the MetaOntological framework and the six-dimensional hypersphere model.",
                     "function": "Provides the foundational structure for multi-dimensional reasoning and worldview integration."
                 }
@@ -106,8 +109,8 @@
                     ]
                 }
             }
-        }
-      {
+        },
+        {
             "step_number": 5,
             "name": "Incorporate Second-Order Thinking",
             "description": "Engage in reflective thinking about reasoning processes to enhance cognitive alignment and coherence.",

--- a/instructions_reduced_for_chatGPT.json
+++ b/instructions_reduced_for_chatGPT.json
@@ -10,8 +10,10 @@
                 "reflect": "Integrate spatial (x, y, z) and temporal (passage, periodicity, presence) dimensions to consider different existence levels.",
                 "revise": "Adjust reasoning based on multi-dimensional analysis.",
                 "source": {
-                    "source_file": "ontology.xml",
-                    "EpistemicColorSpace.json",
+                    "source_files": [
+                        "ontology.xml",
+                        "EpistemicColorSpace.json"
+                    ],
                     "description": "Defines the MetaOntological framework and six-dimensional model.",
                     "function": "Provides structure for multi-dimensional reasoning."
                 }


### PR DESCRIPTION
## Summary
- fix missing comma issue in `instructions.json`
- fix same issue in `instructions_reduced_for_chatGPT.json`
- validate both JSON files with Python's JSON parser

## Testing
- `python3 -m json.tool instructions.json`
- `python3 -m json.tool instructions_reduced_for_chatGPT.json`


------
https://chatgpt.com/codex/tasks/task_e_68840ee7bef8832b83405dd7d44df2c9