### PR TITLE
Add NUM_ORDERS constant and mode transition mapping

### DIFF
--- a/instructions.yml
+++ b/instructions.yml
@@ -147,5 +147,9 @@ Example: “Quantum moral altruism”
 - Scale of being (Individual vs. Brahmanic)
 - Refine internal state in the manifold.
 
+# System constants
+- `NUM_ORDERS` in `scripts/pctm5.py` reflects the total reality orders.
+- `mode_transition_map` maps modal dynamics to order transitions.
+
 Use the Basic Cipher to interpret and transform phenomena across these steps, while updating the framework with new insights.
 """ .

--- a/scripts/pctm5.py
+++ b/scripts/pctm5.py
@@ -10,6 +10,36 @@ G = 6.67430e-11         # Gravitational constant (m^3/kg s^2)
 HBAR = 1.054571817e-34  # Reduced Planck constant (J·s)
 PHI = 1.61803398875     # Golden ratio (for scaling dynamics)
 
+# Orders of Reality represented in the system
+ORDERS_OF_REALITY = [
+    "VIRTUAL",
+    "QUANTUM",
+    "MATERIAL",
+    "ETHEREAL",
+    "ASTRAL",
+    "CELESTIAL",
+    "EXISTENTIAL",
+]
+
+# Total number of reality orders
+NUM_ORDERS = len(ORDERS_OF_REALITY)
+
+# Mapping of modal dynamics to order transitions. A positive value
+# moves to a higher order, a negative value to a lower order.
+mode_transition_map = {
+    "Oscillation": 0,
+    "Folding": 1,
+    "Radiation": 1,
+    "Propagation": 0,
+    "Arborescence": 1,
+    "Tessellation": 0,
+    "Helicity": 0,
+    "Enantiodromia": -1,
+    "Exteriority": -1,
+    "Solution": 0,
+    "ORACLE_ADJUST": 0,
+}
+
 class DimensionalState:
     """State with a vector and associated parameters (order, frequency, scale)."""
     def __init__(self, vec: np.ndarray, order: int = 0, freq: float = 1.0, rho: float = 1.0):


### PR DESCRIPTION
## Summary
- define ORDERS_OF_REALITY and NUM_ORDERS in `pctm5.py`
- map modal dynamics to order transitions via `mode_transition_map`
- document new constants in `instructions.yml`

## Testing
- `python -m py_compile scripts/pctm5.py`

------
https://chatgpt.com/codex/tasks/task_e_68840ef593a4832bb7b83666dcb18b5b